### PR TITLE
Add responsive maintenance dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Mantenimiento</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-..." crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="sidebar">
+        <div class="logo">Mantenimiento</div>
+        <ul class="menu">
+            <li data-section="dashboard" class="active"><i class="fa fa-chart-line"></i> <span>Resumen</span></li>
+            <li data-section="equipos"><i class="fa fa-cogs"></i> <span>Equipos</span></li>
+            <li data-section="calendario"><i class="fa fa-calendar"></i> <span>Calendario</span></li>
+            <li data-section="ot"><i class="fa fa-clipboard-list"></i> <span>Órdenes</span></li>
+            <li data-section="kpis"><i class="fa fa-chart-pie"></i> <span>KPIs</span></li>
+            <li data-section="busqueda"><i class="fa fa-search"></i> <span>Búsqueda</span></li>
+            <li data-section="respaldos"><i class="fa fa-database"></i> <span>Respaldos</span></li>
+        </ul>
+    </div>
+    <div class="content">
+        <section id="dashboard" class="active">
+            <h1>Resumen General</h1>
+            <div class="kpi-container">
+                <div class="kpi" id="total-equipos">0 Equipos</div>
+                <div class="kpi" id="ot-abiertas">0 OT Abiertas</div>
+                <div class="kpi" id="tareas-programadas">0 Tareas</div>
+            </div>
+        </section>
+        <section id="equipos">
+            <h1>Gestión de Equipos</h1>
+            <form id="equipo-form">
+                <input type="text" id="equipo-nombre" placeholder="Nombre del equipo" required>
+                <input type="text" id="equipo-descripcion" placeholder="Descripción" required>
+                <button type="submit">Registrar</button>
+            </form>
+            <ul id="lista-equipos" class="lista"></ul>
+        </section>
+        <section id="calendario">
+            <h1>Calendario de Mantenimiento</h1>
+            <form id="tarea-form">
+                <input type="date" id="tarea-fecha" required>
+                <input type="text" id="tarea-descripcion" placeholder="Descripción" required>
+                <button type="submit">Programar</button>
+            </form>
+            <ul id="lista-tareas" class="lista"></ul>
+        </section>
+        <section id="ot">
+            <h1>Órdenes de Trabajo</h1>
+            <form id="ot-form">
+                <input type="text" id="ot-descripcion" placeholder="Descripción" required>
+                <button type="submit">Agregar</button>
+            </form>
+            <ul id="lista-ot" class="lista"></ul>
+        </section>
+        <section id="kpis">
+            <h1>KPIs de Mantenimiento</h1>
+            <div class="kpi-container">
+                <div class="kpi" id="mttr">MTTR: 0</div>
+                <div class="kpi" id="disponibilidad">Disponibilidad: 0%</div>
+                <div class="kpi" id="eficiencia">Eficiencia: 0%</div>
+            </div>
+        </section>
+        <section id="busqueda">
+            <h1>Búsqueda de Equipos</h1>
+            <input type="text" id="buscador" placeholder="Buscar...">
+            <ul id="resultados" class="lista"></ul>
+        </section>
+        <section id="respaldos">
+            <h1>Respaldos</h1>
+            <button id="crear-backup">Crear Backup</button>
+            <input type="file" id="restaurar-backup" accept="application/json">
+        </section>
+    </div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,162 @@
+const menuItems = document.querySelectorAll('.menu li');
+const sections = document.querySelectorAll('section');
+const sidebar = document.querySelector('.sidebar');
+
+// Mobile toggle
+const mobileToggle = document.createElement('div');
+mobileToggle.classList.add('mobile-toggle');
+mobileToggle.innerHTML = '<i class="fa fa-bars"></i>';
+document.body.appendChild(mobileToggle);
+mobileToggle.addEventListener('click', () => sidebar.classList.toggle('show'));
+
+menuItems.forEach(item => {
+    item.addEventListener('click', () => {
+        menuItems.forEach(i => i.classList.remove('active'));
+        item.classList.add('active');
+        const sectionId = item.getAttribute('data-section');
+        sections.forEach(sec => {
+            sec.classList.toggle('active', sec.id === sectionId);
+        });
+        if (window.innerWidth <= 768) sidebar.classList.remove('show');
+    });
+});
+
+function saveLocal(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+}
+function getLocal(key) {
+    const data = localStorage.getItem(key);
+    return data ? JSON.parse(data) : [];
+}
+
+// Equipos
+const equipoForm = document.getElementById('equipo-form');
+const listaEquipos = document.getElementById('lista-equipos');
+
+function renderEquipos() {
+    const equipos = getLocal('equipos');
+    listaEquipos.innerHTML = '';
+    equipos.forEach((eq, index) => {
+        const li = document.createElement('li');
+        li.textContent = `${eq.nombre} - ${eq.descripcion}`;
+        listaEquipos.appendChild(li);
+    });
+    document.getElementById('total-equipos').textContent = `${equipos.length} Equipos`;
+}
+
+equipoForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const nombre = document.getElementById('equipo-nombre').value;
+    const descripcion = document.getElementById('equipo-descripcion').value;
+    const equipos = getLocal('equipos');
+    equipos.push({ nombre, descripcion });
+    saveLocal('equipos', equipos);
+    equipoForm.reset();
+    renderEquipos();
+});
+
+// Tareas
+const tareaForm = document.getElementById('tarea-form');
+const listaTareas = document.getElementById('lista-tareas');
+
+function renderTareas() {
+    const tareas = getLocal('tareas');
+    listaTareas.innerHTML = '';
+    tareas.forEach(t => {
+        const li = document.createElement('li');
+        li.textContent = `${t.fecha} - ${t.descripcion}`;
+        listaTareas.appendChild(li);
+    });
+    document.getElementById('tareas-programadas').textContent = `${tareas.length} Tareas`;
+}
+
+tareaForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const fecha = document.getElementById('tarea-fecha').value;
+    const descripcion = document.getElementById('tarea-descripcion').value;
+    const tareas = getLocal('tareas');
+    tareas.push({ fecha, descripcion });
+    saveLocal('tareas', tareas);
+    tareaForm.reset();
+    renderTareas();
+});
+
+// Ordenes de Trabajo
+const otForm = document.getElementById('ot-form');
+const listaOT = document.getElementById('lista-ot');
+
+function renderOT() {
+    const ordenes = getLocal('ots');
+    listaOT.innerHTML = '';
+    ordenes.forEach(o => {
+        const li = document.createElement('li');
+        li.textContent = o.descripcion;
+        listaOT.appendChild(li);
+    });
+    document.getElementById('ot-abiertas').textContent = `${ordenes.length} OT Abiertas`;
+}
+
+otForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const descripcion = document.getElementById('ot-descripcion').value;
+    const ordenes = getLocal('ots');
+    ordenes.push({ descripcion });
+    saveLocal('ots', ordenes);
+    otForm.reset();
+    renderOT();
+});
+
+// Búsqueda
+const buscador = document.getElementById('buscador');
+const resultados = document.getElementById('resultados');
+
+buscador.addEventListener('input', () => {
+    const equipos = getLocal('equipos');
+    const q = buscador.value.toLowerCase();
+    resultados.innerHTML = '';
+    equipos.filter(e => e.nombre.toLowerCase().includes(q)).forEach(e => {
+        const li = document.createElement('li');
+        li.textContent = `${e.nombre} - ${e.descripcion}`;
+        resultados.appendChild(li);
+    });
+});
+
+// Respaldos
+const crearBackupBtn = document.getElementById('crear-backup');
+const restaurarBackupInput = document.getElementById('restaurar-backup');
+
+crearBackupBtn.addEventListener('click', () => {
+    const data = {
+        equipos: getLocal('equipos'),
+        tareas: getLocal('tareas'),
+        ots: getLocal('ots')
+    };
+    const blob = new Blob([JSON.stringify(data)], {type: 'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'backup.json';
+    a.click();
+    URL.revokeObjectURL(url);
+});
+
+restaurarBackupInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = evt => {
+        const data = JSON.parse(evt.target.result);
+        saveLocal('equipos', data.equipos || []);
+        saveLocal('tareas', data.tareas || []);
+        saveLocal('ots', data.ots || []);
+        renderEquipos();
+        renderTareas();
+        renderOT();
+    };
+    reader.readAsText(file);
+});
+
+// Inicializar
+renderEquipos();
+renderTareas();
+renderOT();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,113 @@
+:root {
+    --bg-color: #f4f6f8;
+    --primary-color: #3498db;
+    --text-color: #333;
+    --sidebar-width: 220px;
+}
+body {
+    margin: 0;
+    font-family: 'Poppins', sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    display: flex;
+}
+.sidebar {
+    width: var(--sidebar-width);
+    background: #fff;
+    box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+    position: fixed;
+    height: 100vh;
+    padding-top: 1rem;
+    transition: transform 0.3s ease;
+}
+.sidebar .logo {
+    text-align: center;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+.menu { list-style: none; padding: 0; margin: 0; }
+.menu li {
+    padding: 0.8rem 1rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    transition: background 0.3s;
+}
+.menu li i { margin-right: 0.5rem; }
+.menu li:hover,
+.menu li.active {
+    background: var(--primary-color);
+    color: #fff;
+}
+.content {
+    margin-left: var(--sidebar-width);
+    padding: 1rem;
+    width: 100%;
+}
+section { display: none; }
+section.active { display: block; }
+form {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    margin-bottom: 1rem;
+}
+form input, form button {
+    padding: 0.5rem;
+    margin-right: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+}
+form button {
+    background: var(--primary-color);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+form button:hover {
+    background: #1e73be;
+}
+.kpi-container {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+.kpi {
+    background: #fff;
+    flex: 1;
+    min-width: 150px;
+    padding: 1rem;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.lista {
+    list-style: none;
+    padding: 0;
+}
+.lista li {
+    background: #fff;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+@media (max-width: 768px) {
+    .sidebar { transform: translateX(-100%); position: fixed; z-index: 100; }
+    .sidebar.show { transform: translateX(0); }
+    .content { margin-left: 0; padding-top: 3rem; }
+    .mobile-toggle {
+        position: fixed;
+        top: 1rem;
+        left: 1rem;
+        background: var(--primary-color);
+        color: #fff;
+        padding: 0.5rem 0.7rem;
+        border-radius: 4px;
+        cursor: pointer;
+        z-index: 101;
+    }
+}


### PR DESCRIPTION
## Summary
- implement a responsive dashboard interface in `index.html`
- style dashboard with modern look in `style.css`
- add `script.js` for navigation and localStorage data management

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68883dbf1f94832897d46f68b409b34f